### PR TITLE
Improvement to the Scorer Interface

### DIFF
--- a/fos-api/src/main/java/com/feedzai/fos/api/KryoScorer.java
+++ b/fos-api/src/main/java/com/feedzai/fos/api/KryoScorer.java
@@ -81,20 +81,6 @@ public class KryoScorer implements Scorer {
     }
 
     @Override
-    public Map<UUID, double[]> score(Map<UUID, Object[]> modelIdsToScorables) throws FOSException {
-        RemoteConnection con = null;
-        try {
-            con = getConnection();
-            Map<UUID, double[]> scores = con.score(modelIdsToScorables);
-            return scores;
-        } catch (Exception e) {
-            throw new FOSException(e.getMessage(), e);
-        } finally {
-            releaseConnection(con);
-        }
-    }
-
-    @Override
     public List<double[]> score(UUID modelId, List<Object[]> scorables) throws FOSException {
         RemoteConnection con = null;
         try {
@@ -107,6 +93,21 @@ public class KryoScorer implements Scorer {
             releaseConnection(con);
         }
     }
+
+    @Override
+    public double[] score(UUID modelId, Object[] scorable) throws FOSException {
+        RemoteConnection con = null;
+        try {
+            con = getConnection();
+            double[] scores = con.score(modelId, scorable);
+            return scores;
+        } catch (Exception e) {
+            throw new FOSException(e.getMessage(), e);
+        } finally {
+            releaseConnection(con);
+        }
+    }
+
 
     @Override
     public void close() throws FOSException {
@@ -200,12 +201,12 @@ public class KryoScorer implements Scorer {
         }
 
         @Override
-        public Map<UUID, double[]> score(Map<UUID, Object[]> modelIdsToScorables) throws FOSException {
+        public List<double[]> score(UUID modelId, List<Object[]> scorables) throws FOSException {
             throw new FOSException("Not implemented");
         }
 
         @Override
-        public List<double[]> score(UUID modelId, List<Object[]> scorables) throws FOSException {
+        public double[] score(UUID modelId, Object[] scorabl) throws FOSException {
             throw new FOSException("Not implemented");
         }
 

--- a/fos-api/src/main/java/com/feedzai/fos/api/Scorer.java
+++ b/fos-api/src/main/java/com/feedzai/fos/api/Scorer.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  */
 public interface Scorer  {
     /**
-     * Score the <code>scorable</code> against the given <core>modelIds</core>.
+     * Score the <code>scorable</code> against the given <code>modelIds</code>.
      * <p/> The score must be between 0 and 1.
      * <p/> The resulting scores are returned by the same order as the <code>modelIds</code> (modelsIds(pos) » return(pos)).
      *
@@ -47,7 +47,7 @@ public interface Scorer  {
      * @throws FOSException when scoring was not possible
      */
     @NotNull
-    default List<double[]> score(List<UUID> modelIds,Object[] scorable) throws FOSException {
+    default List<double[]> score(List<UUID> modelIds, Object[] scorable) throws FOSException {
         ImmutableList.Builder<double[]> resultsBuilder = ImmutableList.builder();
 
         for (UUID modelId : modelIds) {

--- a/fos-api/src/main/java/com/feedzai/fos/server/remote/api/FOSScorerAdapter.java
+++ b/fos-api/src/main/java/com/feedzai/fos/server/remote/api/FOSScorerAdapter.java
@@ -54,18 +54,18 @@ public class FOSScorerAdapter implements Scorer {
     }
 
     @Override
-    public Map<UUID, double[]> score(Map<UUID, Object[]> uuidMap) throws FOSException {
+    public List<double[]> score(UUID uuid, List<Object[]> objects) throws FOSException {
         try {
-            return scorer.score(uuidMap);
+            return scorer.score(uuid, objects);
         } catch (RemoteException e) {
             throw new FOSException(e);
         }
     }
 
     @Override
-    public List<double[]> score(UUID uuid, List<Object[]> objects) throws FOSException {
+    public double[] score(UUID uuid, Object[] scorable) throws FOSException {
         try {
-            return scorer.score(uuid, objects);
+            return scorer.score(uuid, scorable);
         } catch (RemoteException e) {
             throw new FOSException(e);
         }

--- a/fos-api/src/main/java/com/feedzai/fos/server/remote/api/RemoteScorer.java
+++ b/fos-api/src/main/java/com/feedzai/fos/server/remote/api/RemoteScorer.java
@@ -50,18 +50,6 @@ public interface RemoteScorer extends Remote {
     List<double[]> score(List<UUID> modelIds,Object[] scorable) throws RemoteException;
 
     /**
-     * Score each the scorable (<code>modelIdsToScorables.value</code>) against the given model (<core>modelIdsToScorables.key</core>).
-     * <p/> The score must be between 0 and 999.
-     * <p/> The resulting scores are returned mapped by the provided <code>modelId</code>.
-     *
-     * @param modelIdsToScorables a map from modelId to scorable
-     * @return a map of scores where the key is the <code>modelId</code> (int between 0 and 999)
-     * @throws RemoteException when scoring was not possible
-     */
-    @NotNull
-    Map<UUID, double[]> score(Map<UUID, Object[]> modelIdsToScorables) throws RemoteException;
-
-    /**
      * Score all <code>scorables agains</code> the given <code>modelId</code>.
      * <p/> The score must be between 0 and 999.
      * <p/> The resulting scores are returned in the same order as the <code>scorables</code> (scorables(pos) » return(pos)).
@@ -73,6 +61,19 @@ public interface RemoteScorer extends Remote {
      */
     @NotNull
     List<double[]> score(UUID modelId,List<Object[]> scorables) throws RemoteException;
+
+    /**
+     * Score a single <code>scorable</code> against the given <code>modelId</code>.
+     *
+     * <p/> The score must be between 0 and 999.
+     *
+     * @param modelId   the id of the model
+     * @param scorable  the instance data to score
+     * @return the scores
+     * @throws RemoteException when scoring was not possible
+     */
+    @NotNull
+    double[] score(UUID modelId, Object[] scorable) throws RemoteException;
 
     /**
      * Frees any resources allocated to this scorer.

--- a/fos-impl-dummy/src/main/java/com/feedzai/fos/impl/dummy/DummyScorer.java
+++ b/fos-impl-dummy/src/main/java/com/feedzai/fos/impl/dummy/DummyScorer.java
@@ -56,16 +56,6 @@ public class DummyScorer implements Scorer {
     }
 
     @Override
-    public Map<UUID, double[]> score(Map<UUID, Object[]> modelIdsToScorables) {
-        try {
-            logger.trace("modelIdsToScorables='{}'",  mapper.writeValueAsString(modelIdsToScorables));
-        } catch (IOException e) {
-            logger.error(e.getMessage(), e);
-        }
-        return Collections.EMPTY_MAP;
-    }
-
-    @Override
     public List<double[]> score(UUID modelId, List<Object[]> scorables) {
         try {
             logger.trace("modelId='{}', scorable='{}'",  mapper.writeValueAsString(modelId),  mapper.writeValueAsString(scorables));
@@ -73,6 +63,17 @@ public class DummyScorer implements Scorer {
             logger.error(e.getMessage(), e);
         }
         return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public double[] score(UUID modelId, Object[] scorable) {
+        try {
+            logger.trace("modelId='{}', scorable='{}'",  mapper.writeValueAsString(modelId),  mapper.writeValueAsString(scorable));
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+
+        return new double[0];
     }
 
     @Override

--- a/fos-server/src/main/java/com/feedzai/fos/server/remote/impl/RemoteScorer.java
+++ b/fos-server/src/main/java/com/feedzai/fos/server/remote/impl/RemoteScorer.java
@@ -66,9 +66,9 @@ public class RemoteScorer implements com.feedzai.fos.server.remote.api.RemoteSco
 
     @Override
     @NotNull
-    public Map<UUID, double[]> score(Map<UUID, Object[]> modelIdsToScorables) throws RemoteException {
+    public List<double[]> score(UUID modelId,List<Object[]> scorables) throws RemoteException {
         try {
-            return this.scorer.score(modelIdsToScorables);
+            return this.scorer.score(modelId, scorables);
         } catch (Exception e) {
             logger.error("Caught exception from underlying implementation",e);
             throw new RemoteException("Translated in RMI layer", e);
@@ -77,9 +77,9 @@ public class RemoteScorer implements com.feedzai.fos.server.remote.api.RemoteSco
 
     @Override
     @NotNull
-    public List<double[]> score(UUID modelId,List<Object[]> scorables) throws RemoteException {
+    public double[] score(UUID modelId, Object[] scorable) throws RemoteException {
         try {
-            return this.scorer.score(modelId, scorables);
+            return this.scorer.score(modelId, scorable);
         } catch (Exception e) {
             logger.error("Caught exception from underlying implementation",e);
             throw new RemoteException("Translated in RMI layer", e);

--- a/fos-server/src/test/java/com/feedzai/fos/server/RunnerTest.java
+++ b/fos-server/src/test/java/com/feedzai/fos/server/RunnerTest.java
@@ -46,6 +46,6 @@ public class RunnerTest {
         IRemoteManager manager = (IRemoteManager) registry.lookup(IRemoteManager.class.getSimpleName());
 
         RemoteScorer scorer = (RemoteScorer) registry.lookup(RemoteScorer.class.getSimpleName());
-        Assert.assertEquals(manager.getScorer().score(dummy, null), scorer.score(dummy, null));
+        Assert.assertEquals(manager.getScorer().score(dummy, new Object[0]), scorer.score(dummy, new Object[0]));
     }
 }

--- a/fos-server/src/test/java/com/feedzai/fos/server/remote/impl/RemoteClassifierScorerTest.java
+++ b/fos-server/src/test/java/com/feedzai/fos/server/remote/impl/RemoteClassifierScorerTest.java
@@ -30,6 +30,7 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 /**
@@ -45,16 +46,14 @@ public class RemoteClassifierScorerTest {
     public void testDelegate() throws Exception {
         UUID dummy = UUID.nameUUIDFromBytes(new byte[0]);
 
-        EasyMock.expect(innerScorer.score(dummy,null)).andReturn(null).once();
-        EasyMock.expect(innerScorer.score(dummy,null)).andReturn(null).once();
-        EasyMock.expect(innerScorer.score(null)).andReturn(null).once();
+        EasyMock.expect(innerScorer.score(dummy, new ArrayList<>())).andReturn(null).once();
+        EasyMock.expect(innerScorer.score(dummy, new Object[0])).andReturn(null).once();
 
         PowerMock.replay(innerScorer);
 
         RemoteScorer remote = new RemoteScorer(innerScorer);
-        remote.score(dummy,null);
-        remote.score(dummy,null);
-        remote.score(null);
+        remote.score(dummy, new ArrayList<>());
+        remote.score(dummy, new Object[0]);
 
         PowerMock.verifyAll();
     }


### PR DESCRIPTION
Removed method that computes scores given a map of model uuids to scorables.
Added default implementation for some methods.

This change *does break the API* and will require minor changes to other models. Overall it makes the implementation of new `Scorer`s much easier.